### PR TITLE
Rename F2SE project to F2MPx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(F2SE)
+project(F2MPx)
 
 # Set C++ standard to C++20
 set(CMAKE_CXX_STANDARD 20)
@@ -21,31 +21,27 @@ else()
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m32")
 endif()
 
-# Add source files
-set(SOURCES
-    src/Main.cpp
-    src/Game/GameAddresses.cpp
-    src/Game/GameAddresses.h
-    src/Game/SkillSystem.cpp
-    src/Game/SkillSystem.h
+# Collect all source files recursively
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS
+    "*.cpp"
 )
 
 # Create the executable
-add_executable(F2SE WIN32 ${SOURCES})
+add_executable(F2MPx WIN32 ${SOURCES})
 
 # Set output directories
-set_target_properties(F2SE PROPERTIES
+set_target_properties(F2MPx PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
 # Add include directories
-target_include_directories(F2SE PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
+target_include_directories(F2MPx PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 # Windows-specific settings
 if(WIN32)
-    target_compile_definitions(F2SE PRIVATE
+    target_compile_definitions(F2MPx PRIVATE
         WIN32_LEAN_AND_MEAN
         NOMINMAX
         _CRT_SECURE_NO_WARNINGS
@@ -53,7 +49,7 @@ if(WIN32)
 endif()
 
 # Link against Windows libraries
-target_link_libraries(F2SE PRIVATE
+target_link_libraries(F2MPx PRIVATE
     kernel32
     user32
 ) 

--- a/Common/Types.h
+++ b/Common/Types.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <functional>
 
-namespace F2SE {
+namespace F2MPx {
 
 // Version information
 constexpr int VERSION_MAJOR = 0;
@@ -257,4 +257,4 @@ public:
     virtual const char* GetVersion() = 0;
 };
 
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Core/ScriptExtender.cpp
+++ b/Core/ScriptExtender.cpp
@@ -5,7 +5,7 @@
 #include "../Script/ScriptManager.h"
 #include <iostream>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Core {
 
 ScriptExtender& ScriptExtender::GetInstance() {
@@ -14,38 +14,38 @@ ScriptExtender& ScriptExtender::GetInstance() {
 }
 
 bool ScriptExtender::Initialize() {
-    std::cout << "F2SE: Initializing Script Extender v" 
+    std::cout << "F2MPx: Initializing Script Extender v" 
               << VERSION_MAJOR << "." 
               << VERSION_MINOR << "." 
               << VERSION_PATCH << std::endl;
 
     // Initialize subsystems
     if (!Memory::MemoryManager::GetInstance().Initialize()) {
-        std::cout << "F2SE: Failed to initialize Memory Manager" << std::endl;
+        std::cout << "F2MPx: Failed to initialize Memory Manager" << std::endl;
         return false;
     }
 
     if (!Hooks::HookManager::GetInstance().Initialize()) {
-        std::cout << "F2SE: Failed to initialize Hook Manager" << std::endl;
+        std::cout << "F2MPx: Failed to initialize Hook Manager" << std::endl;
         return false;
     }
 
     if (!Plugin::PluginManager::GetInstance().Initialize()) {
-        std::cout << "F2SE: Failed to initialize Plugin Manager" << std::endl;
+        std::cout << "F2MPx: Failed to initialize Plugin Manager" << std::endl;
         return false;
     }
 
     if (!Script::ScriptManager::GetInstance().Initialize()) {
-        std::cout << "F2SE: Failed to initialize Script Manager" << std::endl;
+        std::cout << "F2MPx: Failed to initialize Script Manager" << std::endl;
         return false;
     }
 
-    std::cout << "F2SE: Initialization complete" << std::endl;
+    std::cout << "F2MPx: Initialization complete" << std::endl;
     return true;
 }
 
 void ScriptExtender::Shutdown() {
-    std::cout << "F2SE: Shutting down..." << std::endl;
+    std::cout << "F2MPx: Shutting down..." << std::endl;
 
     // Shutdown in reverse order
     Script::ScriptManager::GetInstance().Shutdown();
@@ -53,7 +53,7 @@ void ScriptExtender::Shutdown() {
     Hooks::HookManager::GetInstance().Shutdown();
     Memory::MemoryManager::GetInstance().Shutdown();
 
-    std::cout << "F2SE: Shutdown complete" << std::endl;
+    std::cout << "F2MPx: Shutdown complete" << std::endl;
 }
 
 bool ScriptExtender::LoadPlugin(const std::string& pluginPath) {
@@ -81,4 +81,4 @@ PlayerData* ScriptExtender::GetPlayerData() {
 }
 
 } // namespace Core
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Core/ScriptExtender.h
+++ b/Core/ScriptExtender.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <windows.h>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Core {
 
 class ScriptExtender {
@@ -34,4 +34,4 @@ private:
 };
 
 } // namespace Core
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/F2MPx.cpp
+++ b/F2MPx.cpp
@@ -54,14 +54,14 @@ int __stdcall Hook_ScriptProc(void* script, int param) {
 
 void __stdcall Hook_GameInit() {
     // Pre game init
-    std::cout << "F2SE: Initializing..." << std::endl;
+    std::cout << "F2MPx: Initializing..." << std::endl;
 
     // Call original init
     orig_GameInit();
 
     // Post game init
     g_gameInitialized = true;
-    std::cout << "F2SE: Initialization complete" << std::endl;
+    std::cout << "F2MPx: Initialization complete" << std::endl;
 }
 
 // Plugin system
@@ -79,7 +79,7 @@ bool LoadPlugin(const char* pluginPath) {
     plugin.handle = LoadLibraryA(pluginPath);
     
     if (!plugin.handle) {
-        std::cout << "F2SE: Failed to load plugin: " << pluginPath << std::endl;
+        std::cout << "F2MPx: Failed to load plugin: " << pluginPath << std::endl;
         return false;
     }
 
@@ -87,20 +87,20 @@ bool LoadPlugin(const char* pluginPath) {
     plugin.Shutdown = (void (__cdecl *)(void))GetProcAddress(plugin.handle, "Shutdown");
     
     if (!plugin.Initialize || !plugin.Shutdown) {
-        std::cout << "F2SE: Plugin missing required functions: " << pluginPath << std::endl;
+        std::cout << "F2MPx: Plugin missing required functions: " << pluginPath << std::endl;
         FreeLibrary(plugin.handle);
         return false;
     }
 
     if (!plugin.Initialize()) {
-        std::cout << "F2SE: Plugin initialization failed: " << pluginPath << std::endl;
+        std::cout << "F2MPx: Plugin initialization failed: " << pluginPath << std::endl;
         FreeLibrary(plugin.handle);
         return false;
     }
 
     plugin.name = pluginPath;
     plugins.push_back(plugin);
-    std::cout << "F2SE: Loaded plugin: " << pluginPath << std::endl;
+    std::cout << "F2MPx: Loaded plugin: " << pluginPath << std::endl;
     return true;
 }
 
@@ -130,7 +130,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
             FILE* dummy;
             freopen_s(&dummy, "CONOUT$", "w", stdout);
 
-            std::cout << "F2SE: Initializing Script Extender..." << std::endl;
+            std::cout << "F2MPx: Initializing Script Extender..." << std::endl;
 
             // Get original function addresses
             orig_MainLoop = (tMainLoop)GetFallout2Function(0x1234);  // Replace with actual offset
@@ -147,11 +147,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
             
             LONG error = DetourTransactionCommit();
             if (error != NO_ERROR) {
-                std::cout << "F2SE: Failed to install hooks" << std::endl;
+                std::cout << "F2MPx: Failed to install hooks" << std::endl;
                 return FALSE;
             }
 
-            std::cout << "F2SE: Hooks installed successfully" << std::endl;
+            std::cout << "F2MPx: Hooks installed successfully" << std::endl;
 
             // Load plugins
             LoadPlugin("plugins/example.dll");

--- a/F2MPx.h
+++ b/F2MPx.h
@@ -3,7 +3,7 @@
 #include <windows.h>
 #include <string>
 
-namespace F2SE {
+namespace F2MPx {
 
 // Version information
 constexpr int VERSION_MAJOR = 0;
@@ -81,4 +81,4 @@ extern "C" {
     PlayerData* __declspec(dllexport) GetPlayerData();
 }
 
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Game/CombatSystem.cpp
+++ b/Game/CombatSystem.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <stdexcept>
 
-namespace F2SE::Game {
+namespace F2MPx::Game {
 
 bool CombatSystem::Initialize() {
     if (_inCombat) {
@@ -207,4 +207,4 @@ void CombatSystem::SetInitiative(uint32_t actorId, int32_t initiative) {
     }
 }
 
-} // namespace F2SE::Game 
+} // namespace F2MPx::Game 

--- a/Game/CombatSystem.h
+++ b/Game/CombatSystem.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <memory>
 
-namespace F2SE::Game {
+namespace F2MPx::Game {
 
 class Actor;
 
@@ -74,4 +74,4 @@ private:
     std::vector<CombatAction> _queuedActions;
 };
 
-} // namespace F2SE::Game 
+} // namespace F2MPx::Game 

--- a/Game/GameAddresses.cpp
+++ b/Game/GameAddresses.cpp
@@ -2,7 +2,7 @@
 #include <Windows.h>
 #include <stdexcept>
 
-namespace F2SE::Game {
+namespace F2MPx::Game {
 
 int8_t GameAddresses::GetStat(uintptr_t address) {
     int8_t value = 0;
@@ -40,4 +40,4 @@ bool GameAddresses::IsValidStatValue(int8_t value, int8_t min, int8_t max) {
     return value >= min && value <= max;
 }
 
-} // namespace F2SE::Game 
+} // namespace F2MPx::Game 

--- a/Game/GameAddresses.h
+++ b/Game/GameAddresses.h
@@ -3,7 +3,7 @@
 #include <windows.h>
 #include <cstdint>
 
-namespace F2SE::Game {
+namespace F2MPx::Game {
 
 // Memory addresses for different game versions
 struct GameAddresses {
@@ -115,4 +115,4 @@ struct DamageComputation {
 };
 #pragma pack(pop)
 
-} // namespace F2SE::Game 
+} // namespace F2MPx::Game 

--- a/Game/GameManager.cpp
+++ b/Game/GameManager.cpp
@@ -1,7 +1,7 @@
 #include "GameManager.h"
 #include <iostream>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Game {
 
 GameManager& GameManager::GetInstance() {
@@ -14,23 +14,23 @@ bool GameManager::Initialize() {
         return true;
     }
 
-    std::cout << "F2SE: Detecting game version..." << std::endl;
+    std::cout << "F2MPx: Detecting game version..." << std::endl;
     _version = DetectGameVersion();
     
     if (_version == GameVersion::Unknown) {
-        std::cout << "F2SE: Failed to detect game version" << std::endl;
+        std::cout << "F2MPx: Failed to detect game version" << std::endl;
         return false;
     }
 
     InitializeAddresses();
     
     if (!ValidateAddresses()) {
-        std::cout << "F2SE: Failed to validate game addresses" << std::endl;
+        std::cout << "F2MPx: Failed to validate game addresses" << std::endl;
         return false;
     }
 
     _initialized = true;
-    std::cout << "F2SE: Game Manager initialized for version " 
+    std::cout << "F2MPx: Game Manager initialized for version " 
               << (_version == GameVersion::US_102 ? "US 1.02" : "US 1.02d") 
               << std::endl;
     return true;
@@ -220,4 +220,4 @@ bool GameManager::ValidateAddresses() {
 }
 
 } // namespace Game
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Game/GameManager.h
+++ b/Game/GameManager.h
@@ -4,7 +4,7 @@
 #include "../Memory/MemoryManager.h"
 #include <string>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Game {
 
 class GameManager {
@@ -66,4 +66,4 @@ private:
 };
 
 } // namespace Game
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Game/GamePatcher.cpp
+++ b/Game/GamePatcher.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 #include "GamePatches.h"
 
-namespace F2SE {
+namespace F2MPx {
 namespace Game {
 
 GamePatcher& GamePatcher::GetInstance() {
@@ -194,4 +194,4 @@ bool GamePatcher::ReadMemory(DWORD address, void* buffer, size_t size) {
 }
 
 } // namespace Game
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Game/GamePatches.h
+++ b/Game/GamePatches.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace F2SE {
+namespace F2MPx {
 namespace Game {
 
 // Memory patterns to find addresses dynamically
@@ -95,4 +95,4 @@ private:
 };
 
 } // namespace Game
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Game/GameState.cpp
+++ b/Game/GameState.cpp
@@ -1,7 +1,7 @@
 #include "GameState.h"
 #include <iostream>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Game {
 
 GameState& GameState::GetInstance() {
@@ -220,4 +220,4 @@ bool GameState::LoadState(const std::string& filename) {
 }
 
 } // namespace Game
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Game/GameState.h
+++ b/Game/GameState.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <unordered_map>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Game {
 
 // Forward declarations
@@ -125,4 +125,4 @@ private:
 };
 
 } // namespace Game
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Game/SkillSystem.cpp
+++ b/Game/SkillSystem.cpp
@@ -2,7 +2,7 @@
 #include <Windows.h>
 #include <stdexcept>
 
-namespace F2SE::Game {
+namespace F2MPx::Game {
 
 bool SkillSystem::Initialize() {
     return InstallHooks();
@@ -108,4 +108,4 @@ bool SkillSystem::ValidateSkillLevel(int level) {
     return level >= MIN_SKILL_LEVEL && level <= MAX_SKILL_LEVEL;
 }
 
-} // namespace F2SE::Game 
+} // namespace F2MPx::Game 

--- a/Game/SkillSystem.h
+++ b/Game/SkillSystem.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <array>
 
-namespace F2SE::Game {
+namespace F2MPx::Game {
 
 class SkillSystem {
 public:
@@ -70,4 +70,4 @@ private:
     static constexpr int MAX_TAG_SKILLS = 4;
 };
 
-} // namespace F2SE::Game 
+} // namespace F2MPx::Game 

--- a/HOOKING.md
+++ b/HOOKING.md
@@ -1,40 +1,40 @@
-# F2SE Hooking System Documentation
+# F2MPx Hooking System Documentation
 
 ## Overview
 
-The Fallout 2 Script Extender (F2SE) uses a sophisticated hooking system to integrate with various game processes and extend their functionality. This document explains the key hooking mechanisms and their purposes.
+The Fallout 2 Script Extender (F2MPx) uses a sophisticated hooking system to integrate with various game processes and extend their functionality. This document explains the key hooking mechanisms and their purposes.
 
 ## Save Game Integration
 
 ### Save Process Hook
-F2SE hooks into Fallout 2's save game process at two key points:
+F2MPx hooks into Fallout 2's save game process at two key points:
 1. Pre-Save: Called before the game writes its save data
-   - Allows F2SE to prepare additional data that needs to be saved
+   - Allows F2MPx to prepare additional data that needs to be saved
    - Can prevent saving if script-extended features are in an unsafe state
    - Triggers the `OnPreSave` event for scripts to handle pre-save cleanup
 
 2. Post-Save: Called after the game has written its save data
-   - Writes F2SE-specific data to a co-save file (.F2SE)
+   - Writes F2MPx-specific data to a co-save file (.F2MPx)
    - Stores extended script data, custom forms, and plugin state
    - Triggers the `OnPostSave` event for scripts
 
 ### Load Process Hook
-Similarly, F2SE hooks the load process:
+Similarly, F2MPx hooks the load process:
 1. Pre-Load: Called before the game loads save data
-   - Validates F2SE co-save file existence and version compatibility
+   - Validates F2MPx co-save file existence and version compatibility
    - Prepares script engine for state restoration
    - Triggers the `OnPreLoad` event
 
 2. Post-Load: Called after game data is loaded
-   - Reads and restores F2SE-specific data
+   - Reads and restores F2MPx-specific data
    - Relinks script references and reconstructs plugin state
    - Triggers the `OnPostLoad` event
 
 ### Co-Save File Structure
-The F2SE co-save file (.F2SE) contains:
+The F2MPx co-save file (.F2MPx) contains:
 ```
 Header:
-- Magic number ('F2SE')
+- Magic number ('F2MPx')
 - Version information
 - Save timestamp
 
@@ -53,7 +53,7 @@ State Information:
 ## Memory Hooks
 
 ### Direct Memory Access
-F2SE uses several methods to access and modify game memory:
+F2MPx uses several methods to access and modify game memory:
 1. **Virtual Memory Hooks**
    - Patches specific memory addresses to redirect execution
    - Uses trampolines for safe function interception
@@ -100,9 +100,9 @@ Plugins can register for various events:
 ```cpp
 // Example plugin hook registration
 void RegisterPluginHooks() {
-    F2SE::HookManager::Register(HookType::PreSave, OnPreSave);
-    F2SE::HookManager::Register(HookType::PostLoad, OnPostLoad);
-    F2SE::HookManager::Register(HookType::GameLoop, OnFrame);
+    F2MPx::HookManager::Register(HookType::PreSave, OnPreSave);
+    F2MPx::HookManager::Register(HookType::PostLoad, OnPostLoad);
+    F2MPx::HookManager::Register(HookType::GameLoop, OnFrame);
 }
 ```
 
@@ -110,7 +110,7 @@ void RegisterPluginHooks() {
 Plugins can define custom hook points:
 ```cpp
 // Example custom hook definition
-F2SE::HookPoint* customHook = F2SE::HookManager::CreateHook(
+F2MPx::HookPoint* customHook = F2MPx::HookManager::CreateHook(
     "MyPlugin::CustomEvent",
     0x004A5B60,  // Memory address
     HookType::Call,
@@ -143,13 +143,13 @@ F2SE::HookPoint* customHook = F2SE::HookManager::CreateHook(
 ## Debugging
 
 ### Hook Debugging
-F2SE provides several debugging tools:
+F2MPx provides several debugging tools:
 ```cpp
 // Enable hook debugging
-F2SE::HookManager::SetDebugMode(true);
+F2MPx::HookManager::SetDebugMode(true);
 
 // Log hook events
-F2SE::HookManager::LogHookEvent(
+F2MPx::HookManager::LogHookEvent(
     "SaveGame",
     "Pre-save hook executed",
     LogLevel::Debug
@@ -160,7 +160,7 @@ F2SE::HookManager::LogHookEvent(
 Tools for validating memory operations:
 ```cpp
 // Validate memory region
-bool isValid = F2SE::Memory::ValidateAddress(
+bool isValid = F2MPx::Memory::ValidateAddress(
     address,
     size,
     MemoryFlags::Read | MemoryFlags::Write
@@ -170,17 +170,17 @@ bool isValid = F2SE::Memory::ValidateAddress(
 ## Extended Features
 
 ### Input System Extension
-F2SE enhances the game's input system:
+F2MPx enhances the game's input system:
 ```cpp
 // Register custom key bindings
-F2SE::InputManager::RegisterHotkey(
+F2MPx::InputManager::RegisterHotkey(
     "MyMod::SpecialAction",
     VK_F5,
     [](){ /* Custom action */ }
 );
 
 // Extended input events
-F2SE::InputManager::RegisterInputHandler(
+F2MPx::InputManager::RegisterInputHandler(
     InputEventType::MouseWheel,
     [](const InputEvent& e) {
         // Handle mouse wheel for custom UI
@@ -195,7 +195,7 @@ F2SE::InputManager::RegisterInputHandler(
    - Add custom HUD elements
    ```cpp
    // Create custom menu
-   auto menu = F2SE::UI::CreateMenu("MyMod::CustomMenu");
+   auto menu = F2MPx::UI::CreateMenu("MyMod::CustomMenu");
    menu->AddElement(
        "Button",
        {x: 100, y: 100, width: 200, height: 30},
@@ -209,7 +209,7 @@ F2SE::InputManager::RegisterInputHandler(
    - Dynamic item modifications
    ```cpp
    // Add custom item property
-   F2SE::Items::RegisterProperty(
+   F2MPx::Items::RegisterProperty(
        "CustomDurability",
        PropertyType::Float,
        100.0f  // default value
@@ -221,7 +221,7 @@ F2SE::InputManager::RegisterInputHandler(
 1. **Extended Script Functions**
    ```cpp
    // Register custom script function
-   F2SE::ScriptEngine::RegisterFunction(
+   F2MPx::ScriptEngine::RegisterFunction(
        "GetCustomStat",
        [](ScriptContext& ctx) {
            auto statId = ctx.GetArg<int>(0);
@@ -233,7 +233,7 @@ F2SE::InputManager::RegisterInputHandler(
 2. **Event System**
    ```cpp
    // Register custom event
-   F2SE::Events::Register(
+   F2MPx::Events::Register(
        "OnCustomAction",
        [](const EventArgs& args) {
            // Handle custom event
@@ -249,7 +249,7 @@ F2SE::InputManager::RegisterInputHandler(
    - Dynamic world events
    ```cpp
    // Add custom map marker
-   F2SE::WorldMap::AddMarker(
+   F2MPx::WorldMap::AddMarker(
        {x: 1500, y: 2000},
        "CustomLocation",
        MarkerType::Quest
@@ -262,7 +262,7 @@ F2SE::InputManager::RegisterInputHandler(
    - Dynamic NPC scheduling
    ```cpp
    // Register custom AI package
-   F2SE::AI::RegisterPackage(
+   F2MPx::AI::RegisterPackage(
        "CustomBehavior",
        [](NPC* npc) {
            // Implement custom behavior
@@ -278,7 +278,7 @@ F2SE::InputManager::RegisterInputHandler(
    - Player management
    ```cpp
    // Broadcast custom event
-   F2SE::Network::Broadcast(
+   F2MPx::Network::Broadcast(
        "PlayerAction",
        {
            {"playerId", playerId},
@@ -294,7 +294,7 @@ F2SE::InputManager::RegisterInputHandler(
    - Player interaction handlers
    ```cpp
    // Register multiplayer-aware function
-   F2SE::MP::RegisterFunction(
+   F2MPx::MP::RegisterFunction(
        "SyncedAction",
        [](const NetworkContext& ctx) {
            // Handle synchronized action
@@ -310,7 +310,7 @@ F2SE::InputManager::RegisterInputHandler(
    - Dynamic lighting
    ```cpp
    // Register custom shader
-   F2SE::Graphics::RegisterShader(
+   F2MPx::Graphics::RegisterShader(
        "CustomEffect",
        "shaders/custom.hlsl",
        ShaderType::PostProcess
@@ -323,7 +323,7 @@ F2SE::InputManager::RegisterInputHandler(
    - Dynamic mesh modification
    ```cpp
    // Load custom model
-   auto model = F2SE::Models::Load(
+   auto model = F2MPx::Models::Load(
        "models/custom.nif",
        ModelFlags::Dynamic | ModelFlags::Animated
    );
@@ -334,7 +334,7 @@ F2SE::InputManager::RegisterInputHandler(
 1. **Extended Console Commands**
    ```cpp
    // Register debug command
-   F2SE::Console::RegisterCommand(
+   F2MPx::Console::RegisterCommand(
        "ShowCustomDebug",
        [](const CommandArgs& args) {
            // Display debug information
@@ -345,9 +345,9 @@ F2SE::InputManager::RegisterInputHandler(
 2. **Performance Monitoring**
    ```cpp
    // Monitor performance
-   F2SE::Debug::StartPerfCounter("CustomFeature");
+   F2MPx::Debug::StartPerfCounter("CustomFeature");
    // ... code to monitor ...
-   auto metrics = F2SE::Debug::StopPerfCounter("CustomFeature");
+   auto metrics = F2MPx::Debug::StopPerfCounter("CustomFeature");
    ```
 
 ### Mod Management
@@ -355,7 +355,7 @@ F2SE::InputManager::RegisterInputHandler(
 1. **Plugin Dependencies**
    ```cpp
    // Define plugin requirements
-   F2SE::Plugins::RequirePlugin(
+   F2MPx::Plugins::RequirePlugin(
        "RequiredMod.esp",
        "1.2.0",
        VersionCompare::GreaterOrEqual
@@ -365,7 +365,7 @@ F2SE::InputManager::RegisterInputHandler(
 2. **Resource Management**
    ```cpp
    // Register custom resource handler
-   F2SE::Resources::RegisterHandler(
+   F2MPx::Resources::RegisterHandler(
        ".custom",
        [](const std::string& path) {
            // Handle custom resource loading
@@ -378,7 +378,7 @@ F2SE::InputManager::RegisterInputHandler(
 1. **INI Settings**
    ```cpp
    // Register custom settings
-   F2SE::Config::RegisterSetting(
+   F2MPx::Config::RegisterSetting(
        "MyMod",
        "CustomFeature",
        true,  // default value
@@ -389,7 +389,7 @@ F2SE::InputManager::RegisterInputHandler(
 2. **User Preferences**
    ```cpp
    // Handle user preferences
-   F2SE::Preferences::Register(
+   F2MPx::Preferences::Register(
        "MyMod::Settings",
        [](json& settings) {
            // Load/save user preferences

--- a/Hooks/HookManager.h
+++ b/Hooks/HookManager.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <functional>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Hooks {
 
 // Hook types
@@ -72,4 +72,4 @@ private:
 };
 
 } // namespace Hooks
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Main.cpp
+++ b/Main.cpp
@@ -11,14 +11,14 @@ HINSTANCE g_hInstance = nullptr;
 bool g_isRunning = false;
 HHOOK g_keyboardHook = nullptr;
 bool g_consoleVisible = false;
-const char* VERSION = "F2SE v0.01";
+const char* VERSION = "F2MPx v0.01";
 HANDLE g_gameProcess = nullptr;
 DWORD g_processId = 0;
 HWND g_consoleWindow = nullptr;
 
 // Function declarations
-bool InitializeF2SE();
-void ShutdownF2SE();
+bool InitializeF2MPx();
+void ShutdownF2MPx();
 void ShowError(const std::string& message);
 bool LaunchGame();
 void SetupConsole();
@@ -45,9 +45,9 @@ int WINAPI WinMain(
             return 1;
         }
 
-        // Initialize F2SE
-        if (!InitializeF2SE()) {
-            ShowError("Failed to initialize F2SE");
+        // Initialize F2MPx
+        if (!InitializeF2MPx()) {
+            ShowError("Failed to initialize F2MPx");
             return 1;
         }
 
@@ -84,7 +84,7 @@ int WINAPI WinMain(
             Sleep(10); // Prevent high CPU usage
         }
 
-        ShutdownF2SE();
+        ShutdownF2MPx();
         return static_cast<int>(msg.wParam);
     }
     catch (const std::exception& e) {
@@ -93,19 +93,19 @@ int WINAPI WinMain(
     }
 }
 
-bool InitializeF2SE() {
+bool InitializeF2MPx() {
     // Initialize systems
-    if (!F2SE::Game::SkillSystem::Initialize()) {
+    if (!F2MPx::Game::SkillSystem::Initialize()) {
         ShowError("Failed to initialize Skill System");
         return false;
     }
 
     // TODO: Initialize other systems
-    std::cout << "F2SE initialized successfully\n";
+    std::cout << "F2MPx initialized successfully\n";
     return true;
 }
 
-void ShutdownF2SE() {
+void ShutdownF2MPx() {
     // Unhook keyboard
     if (g_keyboardHook) {
         UnhookWindowsHookEx(g_keyboardHook);
@@ -126,7 +126,7 @@ void ShutdownF2SE() {
 }
 
 void ShowError(const std::string& message) {
-    MessageBoxA(nullptr, message.c_str(), "F2SE Error", MB_OK | MB_ICONERROR);
+    MessageBoxA(nullptr, message.c_str(), "F2MPx Error", MB_OK | MB_ICONERROR);
 }
 
 void SetupConsole() {

--- a/Memory/MemoryManager.cpp
+++ b/Memory/MemoryManager.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <psapi.h>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Memory {
 
 MemoryManager& MemoryManager::GetInstance() {
@@ -17,12 +17,12 @@ bool MemoryManager::Initialize() {
     }
 
     if (!GetModuleInfo()) {
-        std::cout << "F2SE: Failed to get module information" << std::endl;
+        std::cout << "F2MPx: Failed to get module information" << std::endl;
         return false;
     }
 
     _initialized = true;
-    std::cout << "F2SE: Memory Manager initialized" << std::endl;
+    std::cout << "F2MPx: Memory Manager initialized" << std::endl;
     return true;
 }
 
@@ -51,7 +51,7 @@ bool MemoryManager::ReadMemory(DWORD address, void* buffer, size_t size) {
         return true;
     }
     __except(EXCEPTION_EXECUTE_HANDLER) {
-        std::cout << "F2SE: Memory read failed at " << std::hex << address << std::endl;
+        std::cout << "F2MPx: Memory read failed at " << std::hex << address << std::endl;
         return false;
     }
 }
@@ -63,7 +63,7 @@ bool MemoryManager::WriteMemory(DWORD address, const void* buffer, size_t size) 
 
     DWORD oldProtection;
     if (!VirtualProtect((LPVOID)address, size, PAGE_EXECUTE_READWRITE, &oldProtection)) {
-        std::cout << "F2SE: Failed to unprotect memory at " << std::hex << address << std::endl;
+        std::cout << "F2MPx: Failed to unprotect memory at " << std::hex << address << std::endl;
         return false;
     }
 
@@ -74,7 +74,7 @@ bool MemoryManager::WriteMemory(DWORD address, const void* buffer, size_t size) 
     }
     __except(EXCEPTION_EXECUTE_HANDLER) {
         VirtualProtect((LPVOID)address, size, oldProtection, &oldProtection);
-        std::cout << "F2SE: Memory write failed at " << std::hex << address << std::endl;
+        std::cout << "F2MPx: Memory write failed at " << std::hex << address << std::endl;
         return false;
     }
 }
@@ -281,4 +281,4 @@ bool MemoryManager::ValidateAddress(DWORD address, size_t size) {
 }
 
 } // namespace Memory
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Memory/MemoryManager.h
+++ b/Memory/MemoryManager.h
@@ -4,7 +4,7 @@
 #include <windows.h>
 #include <vector>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Memory {
 
 class MemoryManager {
@@ -55,4 +55,4 @@ private:
 };
 
 } // namespace Memory
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Plugin/Plugin.cpp
+++ b/Plugin/Plugin.cpp
@@ -2,7 +2,7 @@
 #include <Windows.h>
 #include <iostream>
 
-namespace F2SE::Plugin {
+namespace F2MPx::Plugin {
 
 Plugin::Plugin(const std::string& path)
     : _path(path), _handle(nullptr), _isInitialized(false) {
@@ -148,4 +148,4 @@ void Plugin::OnUpdate(float deltaTime) {
     // Regular update logic here
 }
 
-} // namespace F2SE::Plugin 
+} // namespace F2MPx::Plugin 

--- a/Plugin/Plugin.h
+++ b/Plugin/Plugin.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <memory>
 
-namespace F2SE::Plugin {
+namespace F2MPx::Plugin {
 
 struct Version {
     int major;
@@ -102,4 +102,4 @@ protected:
     bool _initialized{false};
 };
 
-} // namespace F2SE::Plugin 
+} // namespace F2MPx::Plugin 

--- a/Plugin/PluginAPI.cpp
+++ b/Plugin/PluginAPI.cpp
@@ -1,7 +1,7 @@
 #include "PluginAPI.h"
 #include <iostream>
 
-namespace F2SE::Plugin {
+namespace F2MPx::Plugin {
 
 bool PluginAPI::Initialize() {
     if (_initialized) {
@@ -75,4 +75,4 @@ std::vector<std::string> PluginAPI::GetRegisteredFunctions() const {
     return result;
 }
 
-} // namespace F2SE::Plugin 
+} // namespace F2MPx::Plugin 

--- a/Plugin/PluginAPI.h
+++ b/Plugin/PluginAPI.h
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <memory>
 
-namespace F2SE::Plugin {
+namespace F2MPx::Plugin {
 
 class PluginAPI {
 public:
@@ -25,4 +25,4 @@ private:
     std::unordered_map<std::string, std::function<void*()>> _functions;
 };
 
-} // namespace F2SE::Plugin 
+} // namespace F2MPx::Plugin 

--- a/Plugin/PluginManager.cpp
+++ b/Plugin/PluginManager.cpp
@@ -3,7 +3,7 @@
 #include <filesystem>
 #include <fstream>
 
-namespace F2SE::Plugin {
+namespace F2MPx::Plugin {
 
 // Fallout 2 supported file extensions
 const std::vector<std::string> SUPPORTED_EXTENSIONS = {
@@ -457,7 +457,7 @@ bool PluginManager::ValidatePlugin(const PluginInfo& info) const {
         return false;
     }
 
-    // Check F2SE version compatibility
+    // Check F2MPx version compatibility
     // You would need to implement proper version comparison here
 
     return true;
@@ -491,4 +491,4 @@ void PluginManager::NotifyPluginEvent(const std::string& event, const std::strin
     // This would be called for various system events that plugins might want to handle
 }
 
-} // namespace F2SE::Plugin 
+} // namespace F2MPx::Plugin 

--- a/Plugin/PluginManager.h
+++ b/Plugin/PluginManager.h
@@ -7,7 +7,7 @@
 #include <functional>
 #include <filesystem>
 
-namespace F2SE::Plugin {
+namespace F2MPx::Plugin {
 
 // Forward declarations
 class Plugin;
@@ -31,7 +31,7 @@ struct PluginInfo {
     std::string author;
     std::string description;
     Version version;
-    Version minF2SEVersion;
+    Version minF2MPxVersion;
     std::vector<std::string> dependencies;
     std::vector<std::string> incompatibilities;
     bool hasScripts;
@@ -156,4 +156,4 @@ private:
     void NotifyPluginEvent(const std::string& event, const std::string& plugin);
 };
 
-} // namespace F2SE::Plugin 
+} // namespace F2MPx::Plugin 

--- a/Plugin/Version.cpp
+++ b/Plugin/Version.cpp
@@ -1,7 +1,7 @@
 #include "Version.h"
 #include <sstream>
 
-namespace F2SE::Plugin {
+namespace F2MPx::Plugin {
 
 Version::Version(uint32_t major, uint32_t minor, uint32_t patch)
     : _major(major), _minor(minor), _patch(patch) {
@@ -81,4 +81,4 @@ uint32_t Version::GetPatch() const {
     return _patch;
 }
 
-} // namespace F2SE::Plugin 
+} // namespace F2MPx::Plugin 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# F2SE  
+# F2MPx  
 
 **Fallout 2 Script Extender — By Frank**
 
-## What is F2SE?
+## What is F2MPx?
 
-F2SE (Fallout 2 Script Extender) is a custom-built runtime extension system designed to hook into Fallout 2's internal engine and provide advanced scripting functionality beyond what the base game allows. Its primary goal was to enable deep access to game memory, support custom scripts, and serve as the foundation for future multiplayer and modding capabilities.
+F2MPx (Fallout 2 Script Extender) is a custom-built runtime extension system designed to hook into Fallout 2's internal engine and provide advanced scripting functionality beyond what the base game allows. Its primary goal was to enable deep access to game memory, support custom scripts, and serve as the foundation for future multiplayer and modding capabilities.
 
-Inspired by tools such as NVSE (New Vegas Script Extender) and FOSE (Fallout 3 Script Extender), F2SE was created from the ground up to work specifically with Fallout 2’s engine. It allows developers to inject scripts at runtime, patch memory structures, hook engine-level behavior, and interact directly with the game state. 
+Inspired by tools such as NVSE (New Vegas Script Extender) and FOSE (Fallout 3 Script Extender), F2MPx was created from the ground up to work specifically with Fallout 2’s engine. It allows developers to inject scripts at runtime, patch memory structures, hook engine-level behavior, and interact directly with the game state. 
 
 The original design included the following features:
 - Memory hooks for real-time game manipulation
@@ -17,7 +17,7 @@ The original design included the following features:
 - UI and input extension support
 - Support for reading engine variables and modifying game logic on-the-fly
 
-F2SE made it possible to develop systems like:
+F2MPx made it possible to develop systems like:
 - Real-time player synchronization for multiplayer mods
 - Dynamic quest, inventory, and combat manipulation
 - In-game debugging tools and overlay systems
@@ -27,19 +27,19 @@ F2SE made it possible to develop systems like:
 
 This project is no longer being actively developed.
 
-While F2SE does technically work — it successfully injects and executes scripts, hooks into Fallout 2’s main game loop, and provides basic patching functionality — it is **extremely incomplete**. Many features are either half-finished, unstable, or untested. There is no versioning system, no user interface, and no safety net for memory patching errors. Use at your own risk.
+While F2MPx does technically work — it successfully injects and executes scripts, hooks into Fallout 2’s main game loop, and provides basic patching functionality — it is **extremely incomplete**. Many features are either half-finished, unstable, or untested. There is no versioning system, no user interface, and no safety net for memory patching errors. Use at your own risk.
 
-F2SE has been officially **discontinued** and will not receive further updates or support in its current form. However, the core concepts and codebase are now being carried forward into **F2MPx**, an upcoming multiplayer mod and engine-layer rewrite for Fallout 2 that includes:
+F2MPx has been officially **discontinued** and will not receive further updates or support in its current form. However, the core concepts and codebase are now being carried forward into **F2MPx**, an upcoming multiplayer mod and engine-layer rewrite for Fallout 2 that includes:
 - Full multiplayer support
 - A rebuilt script extender module
 - Secure networking
 - WASD movement
 - Server authority over player state
 
-All future development will occur under the **F2MPx** project umbrella, which includes a reworked scripting and plugin system based on what was started with F2SE.
+All future development will occur under the **F2MPx** project umbrella, which includes a reworked scripting and plugin system based on what was started with F2MPx.
 
 ## Final Notes
 
-F2SE served as a prototype and internal testbed for future tech in Fallout 2 multiplayer development. If you’re reading this looking for a stable public release or documentation, there isn’t one. This was an experimental dev tool, and it remains rough around the edges.
+F2MPx served as a prototype and internal testbed for future tech in Fallout 2 multiplayer development. If you’re reading this looking for a stable public release or documentation, there isn’t one. This was an experimental dev tool, and it remains rough around the edges.
 
 For future updates and a fully realized system, refer to the F2MPx project.

--- a/Script/Console.cpp
+++ b/Script/Console.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <algorithm>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Script {
 
 Console& Console::GetInstance() {
@@ -16,7 +16,7 @@ bool Console::Initialize() {
         return true;
     }
 
-    std::cout << "F2SE: Initializing Console..." << std::endl;
+    std::cout << "F2MPx: Initializing Console..." << std::endl;
     
     // Initialize console state
     _visible = false;
@@ -26,7 +26,7 @@ bool Console::Initialize() {
     _history.clear();
 
     _initialized = true;
-    std::cout << "F2SE: Console initialized" << std::endl;
+    std::cout << "F2MPx: Console initialized" << std::endl;
     return true;
 }
 
@@ -73,12 +73,12 @@ void Console::ExecuteCommand(const std::string& command) {
     
     // Display result
     if (result.success) {
-        std::cout << "F2SE: Command executed successfully" << std::endl;
+        std::cout << "F2MPx: Command executed successfully" << std::endl;
         if (result.result.type == ScriptParamType::String) {
             std::cout << "Result: " << result.result.stringValue << std::endl;
         }
     } else {
-        std::cout << "F2SE: Command failed - " << result.error << std::endl;
+        std::cout << "F2MPx: Command failed - " << result.error << std::endl;
     }
 
     // Clear current command
@@ -275,4 +275,4 @@ void Console::UpdateDisplay() {
 }
 
 } // namespace Script
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Script/Console.h
+++ b/Script/Console.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <deque>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Script {
 
 // Console command history entry
@@ -67,4 +67,4 @@ private:
 };
 
 } // namespace Script
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Script/EventManager.cpp
+++ b/Script/EventManager.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace F2SE::Script {
+namespace F2MPx::Script {
 
 EventManager& EventManager::GetInstance() {
     static EventManager instance;
@@ -116,4 +116,4 @@ void EventManager::CleanupEvents() {
     }
 }
 
-} // namespace F2SE::Script 
+} // namespace F2MPx::Script 

--- a/Script/EventManager.h
+++ b/Script/EventManager.h
@@ -9,7 +9,7 @@
 #include <variant>
 #include <memory>
 
-namespace F2SE::Script {
+namespace F2MPx::Script {
 
 // Event data types specific to Fallout 2
 using EventData = std::variant<
@@ -79,4 +79,4 @@ private:
     std::mutex _eventMutex;
 };
 
-} // namespace F2SE::Script 
+} // namespace F2MPx::Script 

--- a/Script/ScriptEngine.cpp
+++ b/Script/ScriptEngine.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Script {
 
 ScriptEngine& ScriptEngine::GetInstance() {
@@ -16,13 +16,13 @@ bool ScriptEngine::Initialize() {
         return true;
     }
 
-    std::cout << "F2SE: Initializing Script Engine..." << std::endl;
+    std::cout << "F2MPx: Initializing Script Engine..." << std::endl;
 
     // Register default commands
     RegisterDefaultCommands();
 
     _initialized = true;
-    std::cout << "F2SE: Script Engine initialized" << std::endl;
+    std::cout << "F2MPx: Script Engine initialized" << std::endl;
     return true;
 }
 
@@ -36,12 +36,12 @@ void ScriptEngine::Shutdown() {
 
 bool ScriptEngine::RegisterCommand(const CommandInfo& cmd) {
     if (_commands.find(cmd.name) != _commands.end()) {
-        std::cout << "F2SE: Command '" << cmd.name << "' already registered" << std::endl;
+        std::cout << "F2MPx: Command '" << cmd.name << "' already registered" << std::endl;
         return false;
     }
 
     _commands[cmd.name] = cmd;
-    std::cout << "F2SE: Registered command '" << cmd.name << "'" << std::endl;
+    std::cout << "F2MPx: Registered command '" << cmd.name << "'" << std::endl;
     return true;
 }
 
@@ -296,4 +296,4 @@ void ScriptEngine::RegisterDefaultCommands() {
 }
 
 } // namespace Script
-} // namespace F2SE 
+} // namespace F2MPx 

--- a/Script/ScriptEngine.h
+++ b/Script/ScriptEngine.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <functional>
 
-namespace F2SE {
+namespace F2MPx {
 namespace Script {
 
 // Command flags
@@ -128,4 +128,4 @@ END_COMMAND;
 */
 
 } // namespace Script
-} // namespace F2SE 
+} // namespace F2MPx 


### PR DESCRIPTION
## Summary
- rename all references from **F2SE** to **F2MPx**
- update project files and documentation accordingly
- adjust `CMakeLists.txt` to glob source files and use repository root for includes

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: windows.h missing)*